### PR TITLE
Remove a single type assert

### DIFF
--- a/src/fhir/schema/translate.clj
+++ b/src/fhir/schema/translate.clj
@@ -325,8 +325,12 @@
     (when (= (get-in extension [:url]) "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type")
       (get-in extension [:valueUrl]))))
 
+(defn warn [msg]
+  (println (format "WARNING: %s" msg)))
+
 (defn build-element-type [e]
-  (assert (<= (count (get-in e [:type])) 1) (pr-str e))
+  (when-not (<= (count (get-in e [:type])) 1)
+    (warn (str "More than one type specified: " (get-in e [:type]))))
   (let [type-from-extension (extract-type-from-extension e)
         tp (get-in e [:type 0 :code])]
     (cond type-from-extension (assoc e :type type-from-extension)

--- a/src/transpiler/fhir_schema.clj
+++ b/src/transpiler/fhir_schema.clj
@@ -325,8 +325,12 @@
     (when (= (get-in extension [:url]) "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type")
       (get-in extension [:valueUrl]))))
 
+(defn warn [msg]
+  (println (format "WARNING: %s" msg)))
+
 (defn build-element-type [e]
-  (assert (<= (count (get-in e [:type])) 1) (pr-str e))
+  (when-not (<= (count (get-in e [:type])) 1)
+    (warn (str "More than one type specified: " (get-in e [:type]))))
   (let [type-from-extension (extract-type-from-extension e)
         tp (get-in e [:type 0 :code])]
     (cond type-from-extension (assoc e :type type-from-extension)


### PR DESCRIPTION
Noticed this while parsing CCDA StructureDefs: there are types like
```
{:type [{:code
   "http://hl7.org/cda/stds/core/StructureDefinition/IVL-TS"} {:code
   "http://hl7.org/cda/stds/core/StructureDefinition/EIVL-TS"} {:code
   "http://hl7.org/cda/stds/core/StructureDefinition/PIVL-TS"} {:code
   "http://hl7.org/cda/stds/core/StructureDefinition/SXPR-TS"}],
   :array true, :representation ["typeAttr"], :label "Useable Period",
   :base {:path "TEL.useablePeriod", :min 0, :max "*"}}
```
Which is probably valid, but raises the assertion. Thus this patch—to remove a potentially wrong assertion. Looks good?